### PR TITLE
allow empty pointer

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,23 +105,25 @@ Select.prototype.__proto__ = eventEmitter.prototype;
  */
 Select.prototype.render = function () {
   var me = this;
+  var indent = me.config.pointer.replace(/./g, ' ');
+  var checkedChar = me.config.checked[ me.config.checkedColor ];
+  var uncheckedChar = me.config.unchecked[ me.config.uncheckedColor ];
 
   me.options.forEach(function(option, position){
-    
-    var prefix = ( position === me.pointerPosition ) ? me.config.pointer 
-                                                     : me.config.pointer.replace(/[(\w\W)(\ )]/g, ' ')
 
-    var checked = me.config.multiSelect ? 
-                  me.optionsSelected.indexOf(option) !== -1 ? me.config.checked[ me.config.checkedColor ] 
-                                                            : me.config.unchecked[ me.config.uncheckedColor ] 
+    var isHighlighted = (position === me.pointerPosition);
+    var prefix = isHighlighted ? me.config.pointer : indent;
+
+    var checked = me.config.multiSelect ?
+                  me.optionsSelected.indexOf(option) !== -1 ? checkedChar : uncheckedChar
                   : '';
-    
-    me.currentoption = prefix.trim() ? option : me.currentoption;
-    
-    console.log( prefix[ me.config.pointerColor ] + 
-                (me.config.prepend ? checked : '') + 
+
+    me.currentoption = isHighlighted ? option : me.currentoption;
+
+    console.log( prefix[ me.config.pointerColor ] +
+                (me.config.prepend ? checked : '') +
                 (position === me.pointerPosition && me.config.inverse ? option.text[ 'inverse' ] : option.text) +
-                (me.config.prepend ? '' : checked) 
+                (me.config.prepend ? '' : checked)
     );
   });
   processOut.write(encode('[?25l'));


### PR DESCRIPTION
This is the fix for #11.

I also allowed myself to do a tiny refactoring of the render function:
- declared some vars for readability and micro-optimisation (no need to fetch the value of the checked/unchecked chars in a loop as they don't depend of the subject of the loop)
- shortened the reg-exp from `/[(\w\W)(\ )]/` to `/./` - it should work the same (unless I'm missing something, as the `\w\W` is a bit odd to me - "letter + non-letter or a space"
- and the fix for my issue was, that the condition assumed that if the pointer (or rather indentation) was an empty string -  the element (line) wasn't currently highlighted. It should verify that correctly now.

Let me know if you have any suggestions or would rather do it differently or don't like my additions or anything at all :-)